### PR TITLE
uid: add get_eeprom_serial

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (1.3.2) stable; urgency=medium
+
+  * uid: add get_eeprom_serial
+
+ -- Alexey Ignatov <lexszero@gmail.com>  Sat, 22 Apr 2017 08:03:02 +0300
+
 wb-common (1.3.1) stable; urgency=medium
 
   * leds: fix set_brightness

--- a/wb_common/uid.py
+++ b/wb_common/uid.py
@@ -27,6 +27,19 @@ def get_mmc_serial():
                     return serial
     return None
 
+def get_eeprom_serial(num = 0):
+    if num == 0:
+        eeprom = "4-0057"
+    elif num == 1:
+        eeprom = "5-0057"
+    eeprom = "/sys/bus/i2c/devices/" + eeprom + "/eeprom"
+
+    if os.path.exists(eeprom):
+        mac = bytearray(open(eeprom).read(256)[250:])
+        return ''.join(map(lambda b: format(b, "02x"), mac))
+
+    return None
+
 
 if __name__ == '__main__':
     print("/proc/cpuinfo serial: ", get_cpuinfo_serial())

--- a/wb_common/uid.py
+++ b/wb_common/uid.py
@@ -34,6 +34,11 @@ def get_eth_mac(num = 0):
     mac_path = of_node_path + "/local-mac-address"
     if os.path.exists(mac_path):
         mac = bytearray(open(mac_path).read(6))
+
+        # Check if default address was set by U-Boot (no EEPROM and unprogrammed OTP)
+        if mac[:3] == bytearray([0x00, 0x04, 0x00]):
+            return None
+
         return ''.join(map(lambda b: format(b, "02x"), mac))
 
     return None

--- a/wb_common/uid.py
+++ b/wb_common/uid.py
@@ -27,19 +27,16 @@ def get_mmc_serial():
                     return serial
     return None
 
-def get_eeprom_serial(num = 0):
-    if num == 0:
-        eeprom = "4-0057"
-    elif num == 1:
-        eeprom = "5-0057"
-    eeprom = "/sys/bus/i2c/devices/" + eeprom + "/eeprom"
+def get_eth_mac(num = 0):
+    netdev_path = os.path.realpath("/sys/class/net/eth" + str(num))
+    of_node_path = os.path.realpath(netdev_path + "/../../of_node")
 
-    if os.path.exists(eeprom):
-        mac = bytearray(open(eeprom).read(256)[250:])
+    mac_path = of_node_path + "/local-mac-address"
+    if os.path.exists(mac_path):
+        mac = bytearray(open(mac_path).read(6))
         return ''.join(map(lambda b: format(b, "02x"), mac))
 
     return None
-
 
 if __name__ == '__main__':
     print("/proc/cpuinfo serial: ", get_cpuinfo_serial())


### PR DESCRIPTION
Читает зашитый в EEPROM MAC-адрес и отдает его в виде строчки
```
>>> uid.get_eeprom_serial()
'd88039a45981'
```