### PR TITLE
Feature/wbmqtt improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (1.3.4) stable; urgency=medium
+
+  * wbmqtt: forced to produce only one instance
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 7 Feb 2020 10:11:44 +0300
+
 wb-common (1.3.3) stable; urgency=medium
 
   * beeper: fix stucking in beeping state

--- a/debian/control
+++ b/debian/control
@@ -10,10 +10,10 @@ X-Python3-Version: >= 3.2
 
 Package: python-wb-common
 Architecture: all
-Depends: python, ${misc:Depends}, python-six
+Depends: python, ${misc:Depends}, python-six, python-mosquitto
 Description: Wiren Board Python common library and helpers
 
 Package: python3-wb-common
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-six
+Depends: python3, ${misc:Depends}, python3-six, python3-mosquitto
 Description: Wiren Board Python common library and helpers


### PR DESCRIPTION
wbmqtt - синглтон. Для того, чтобы избежать конструкций вида:
`wbmqtt = None`
`value = wbmqtt.get_next_or_last_value(<device>, <channel>)`  
и последующего 
`try:`
`   wbmqtt = WBMQTT()`
`    periph_common.wbmqtt = wbmqtt`
`finally:`
`    wbmqtt.close()`
в test-suite