### PR TITLE
Feature/paho mqtt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-common (1.5.0) stable; urgency=medium
 
-  * wb_common.wbmqtt is mosquitto/paho-mqtt compatible
+  * wbmqtt: mosquitto/paho-mqtt compatible
+  * wbmqtt: fix py2/3 compatibility
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 10 Aug 2022 13:49:54 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (1.5.0) stable; urgency=medium
+
+  * wb_common.wbmqtt is mosquitto/paho-mqtt compatible
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 10 Aug 2022 13:49:54 +0300
+
 wb-common (1.4.0) stable; urgency=medium
 
   * add procedure to read WB7 serial from /dev/mem
@@ -25,7 +31,7 @@ wb-common (1.3.1) stable; urgency=medium
 
 wb-common (1.3) stable; urgency=medium
 
-  * Add clear_device method, clear errors too on clear* 
+  * Add clear_device method, clear errors too on clear*
 
  -- Evgeny Boger <boger@contactless.ru>  Tue, 07 Mar 2017 19:46:22 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ X-Python3-Version: >= 3.2
 
 Package: python-wb-common
 Architecture: all
-Depends: python, ${misc:Depends}, python-six, busybox, python-mosquitto
+Depends: python, ${misc:Depends}, python-six, busybox
 Description: Wiren Board Python common library and helpers
 
 Package: python3-wb-common

--- a/debian/control
+++ b/debian/control
@@ -10,10 +10,10 @@ X-Python3-Version: >= 3.2
 
 Package: python-wb-common
 Architecture: all
-Depends: python, ${misc:Depends}, python-six, busybox
+Depends: python, ${misc:Depends}, python-six, busybox, python-mosquitto
 Description: Wiren Board Python common library and helpers
 
 Package: python3-wb-common
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-six, busybox
+Depends: python3, ${misc:Depends}, python3-six, busybox, python3-mosquitto | python3-paho-mqtt
 Description: Wiren Board Python common library and helpers


### PR DESCRIPTION
в процессе ковыряний с тест-сьютом (помогал дружить его с py3), выяснилось, что wb_common переехал на py3 в своё время не очень хорошо (в части wbmqtt)

теперь wbmqtt: paho/mosquitto, py2/3 совместимо