### PR TITLE
Fix password authentication for websockets and unix socket connections

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (2.1.1) stable; urgency=medium
+
+  * mqtt_client: fix password authentication for websockets and unix socket connections
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 03 Mar 2023 09:57:00 +0400
+
 wb-common (2.1.0) stable; urgency=medium
 
   * Add MQTT client wrapper

--- a/wb_common/mqtt_client.py
+++ b/wb_common/mqtt_client.py
@@ -22,15 +22,16 @@ class MQTTClient(paho_socket.Client):
 
     def start(self) -> None:
         scheme = self._broker_url.scheme
+
+        if self._broker_url.username:
+            self.username_pw_set(self._broker_url.username, self._broker_url.password)
+
+        if scheme == "ws" and self._broker_url.path:
+            self.ws_set_options(self._broker_url.path)
+
         if scheme == "unix":
             self.sock_connect(self._broker_url.path)
-        elif scheme in ["mqtt-tcp", "tcp"]:
-            if self._broker_url.username:
-                self.username_pw_set(self._broker_url.username, self._broker_url.password)
-            self.connect(self._broker_url.hostname, self._broker_url.port)
-        elif scheme == "ws":
-            if self._broker_url.path:
-                self.ws_set_options(self._broker_url.path)
+        elif scheme in ["mqtt-tcp", "tcp", "ws"]:
             self.connect(self._broker_url.hostname, self._broker_url.port)
         else:
             raise Exception("Unkown mqtt url scheme: " + scheme)


### PR DESCRIPTION
Test instructions:
* create password file
```sh
$ mosquitto_passwd /etc/mosquitto/passwd/default.conf root wirenboard
```
 * unix socket
```sh
$ sed -i 's/allow_anonymous true/allow_anonymous false/' /etc/mosquitto/conf.d/00default_listener.conf
$ echo "password_file /etc/mosquitto/passwd/default.conf" >> /etc/mosquitto/conf.d/00default_listener.conf
$ mqtt-get-dump -b unix://root:wirenboard@/var/run/mosquitto/mosquitto.sock '$SYS/broker/messages/#'
$SYS/broker/messages/received	4902
$SYS/broker/messages/sent	7025
```
 * websocket
```sh
$ sed -i 's/allow_anonymous true/allow_anonymous false/g' /etc/mosquitto/conf.d/10default_listener.conf
$ sed -i 's/acl_file/#acl_file/' /etc/mosquitto/conf.d/10default_listener.conf
$ mqtt-get-dump -b ws://root:wirenboard@127.0.0.1:18883 '$SYS/broker/messages/#'
$SYS/broker/messages/received	5843
$SYS/broker/messages/sent	7969
```