### PR TITLE
Jenkinsfile: publish this package to both releases

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildDebArchAll defaultRunPythonChecks: true
+buildDebArchAll defaultRunPythonChecks: true,
+                repos: ['release', 'devTools']


### PR DESCRIPTION
This is necessary because we want to do pylint checks of other packages which depend on this one. Currently we don't have a good isolated real WB-looking environment for this, so let's publish everything python-ish to dev-tools repo (which is used by devenv natively).

Inspired by https://github.com/wirenboard/wb-nm-helper/pull/54