### PR TITLE
Pass all arguments to MQTTClient parent class constructor

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (2.1.3) stable; urgency=medium
+
+  * MQTT client wrapper: forward all constructor arguments to paho.mqtt.client.Client
+
+ -- Aleksandr Kazadaev <aleksandr.kazadaev@wirenboard.com>  Wed, 03 Apr 2024 15:44:00 +0500
+
 wb-common (2.1.2) stable; urgency=medium
 
   * Fix PKG-INFO

--- a/wb_common/mqtt_client.py
+++ b/wb_common/mqtt_client.py
@@ -8,8 +8,14 @@ DEFAULT_BROKER_URL = "unix:///var/run/mosquitto/mosquitto.sock"
 
 
 class MQTTClient(paho_socket.Client):
-    def __init__(self, client_id_prefix: str, broker_url: str = DEFAULT_BROKER_URL, is_threaded: bool = True, *args,
-                 **kwargs):
+    def __init__(
+        self,
+        client_id_prefix: str,
+        broker_url: str = DEFAULT_BROKER_URL,
+        is_threaded: bool = True,
+        *args,
+        **kwargs,
+    ):
         self._broker_url = urlparse(broker_url)
         self._is_threaded = is_threaded
         kwargs["client_id"] = self.generate_client_id(client_id_prefix)
@@ -35,7 +41,7 @@ class MQTTClient(paho_socket.Client):
         elif scheme in ["mqtt-tcp", "tcp", "ws"]:
             self.connect(self._broker_url.hostname, self._broker_url.port)
         else:
-            raise Exception("Unkown mqtt url scheme: " + scheme)
+            raise Exception("Unknown mqtt url scheme: " + scheme)
 
         if self._is_threaded:
             self.loop_start()

--- a/wb_common/mqtt_client.py
+++ b/wb_common/mqtt_client.py
@@ -8,12 +8,13 @@ DEFAULT_BROKER_URL = "unix:///var/run/mosquitto/mosquitto.sock"
 
 
 class MQTTClient(paho_socket.Client):
-    def __init__(self, client_id_prefix: str, broker_url: str = DEFAULT_BROKER_URL, is_threaded: bool = True):
+    def __init__(self, client_id_prefix: str, broker_url: str = DEFAULT_BROKER_URL, is_threaded: bool = True, *args,
+                 **kwargs):
         self._broker_url = urlparse(broker_url)
         self._is_threaded = is_threaded
-        client_id = self.generate_client_id(client_id_prefix)
-        transport = "websockets" if self._broker_url.scheme == "ws" else "tcp"
-        super().__init__(client_id=client_id, transport=transport)
+        kwargs["client_id"] = self.generate_client_id(client_id_prefix)
+        kwargs["transport"] = "websockets" if self._broker_url.scheme == "ws" else "tcp"
+        super().__init__(*args, **kwargs)
 
     @staticmethod
     def generate_client_id(client_id_prefix: str, suffix_length: int = 8) -> str:


### PR DESCRIPTION
В конструкторе MQTTClient отсутствует возможность передать классу-предку (и в конечном итоге paho.mqtt.Client) аргумент userdata, а в wb-cloud-agent понадобилась сделать это, дабы передать кое-что в коллбэки.