### PR TITLE
MQTT client wrapper: check if port specified

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (2.2.1) stable; urgency=medium
+
+  * MQTT client wrapper: check if port specified
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 05 Sep 2024 11:00:00 +0400
+
 wb-common (2.2.0) stable; urgency=medium
 
   * Fix pylint, no functional changes

--- a/wb_common/mqtt_client.py
+++ b/wb_common/mqtt_client.py
@@ -39,6 +39,8 @@ class MQTTClient(paho_socket.Client):
         if scheme == "unix":
             self.sock_connect(self._broker_url.path)
         elif scheme in ["mqtt-tcp", "tcp", "ws"]:
+            if not self._broker_url.port:
+                raise Exception("No port specified")
             self.connect(self._broker_url.hostname, self._broker_url.port)
         else:
             raise Exception("Unknown mqtt url scheme: " + scheme)


### PR DESCRIPTION
Сейчас если в url не указан порт получаем неочевидную ошибку:
`'<=' not supported between instances of 'NoneType' and 'int'`