### PR TITLE
beeper: fix setup (after pylint changes)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (2.2.4) stable; urgency=medium
+
+  * beeper: fix setup (after pylint changes)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 13 Dec 2024 17:02:11 +0300
+
 wb-common (2.2.3) stable; urgency=medium
 
   * Enable angry pylint. No functional changes

--- a/wb_common/beeper.py
+++ b/wb_common/beeper.py
@@ -17,11 +17,11 @@ class Beeper:
         if not os.path.exists(self.pwm_dir):
             with open(os.path.join(self.PWM_DIR_TEMPLATE, "export"), mode="w", encoding="ascii") as file:
                 file.write(f"{self.pwm_num}\n")
-        self.set(0)
         with open(os.path.join(self.pwm_dir, "period"), mode="w", encoding="ascii") as file:
             file.write(f"{period}\n")
         with open(os.path.join(self.pwm_dir, "duty_cycle"), mode="w", encoding="ascii") as file:
             file.write(f"{duty_cycle}\n")
+        self.set(0)
 
     def beep(self, duration, repeat=1):
         try:  # To prevent from stucking in '1' state


### PR DESCRIPTION
что-то после pylint, бипер перестал бипать

проблема - включение-выключение бипера было через open, write, а стало через with open => в одном месте мы пытались включить ненастроенную пищалку => теперь стало точно включаться => поломалося

погонял на wb7 и 8