### PR TITLE
fix gsm.gsm_get_imei to prevent wb-gen-serial fails in some wb6 cases

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-common (2.2.6) stable; urgency=medium
+
+  * Fix gsm.gsm_get_imei to prevent wb-gen-serial fails in some wb6 cases
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Fri, 11 Apr 2025 21:02:49 +0300
+
 wb-common (2.2.5) stable; urgency=medium
 
   * Fix lintian

--- a/wb_common/gsm.py
+++ b/wb_common/gsm.py
@@ -21,7 +21,7 @@ def init_baudrate():
         raise RuntimeError("gsm init baudrate failed")
 
 
-def get_imei():
+def gsm_get_imei():
     try:
         result = subprocess.run(
             "wb-gsm imei", shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Клиенты заметили, что wb-gen-serial перестал работать (предположительно, wb6 c модемом). Проблема: внедряя pylint, мы зачем-то [потрогали api](https://github.com/wirenboard/wb-common/pull/15/files#diff-e6d63b46d0006e8d79cfd442cb4ea64ae661056940ae74de0708dfae0da8fc60L24) (wb-gen-serial дергает вот [ето)](https://github.com/wirenboard/wb-utils/blob/e1c979bda0305564b395f32ff4ddc1650b244224/utils/bin/wb-gen-serial#L45)

___________________________________
**Что поменялось для пользователей:**
wb-gen-serial перестал вылетать у пользователей wb6 с модемом

___________________________________
**Как проверял/а:**
никак не проверял; wb6 c модемом под рукой нет; но, судя по выхлопу трейсбека, проблема довольно очевидная
![image](https://github.com/user-attachments/assets/30c992c7-7652-49b4-81c4-ed2ea8f17d09)


