### PR TITLE
Various fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+wb-common (2.3.1) stable; urgency=medium
+
+  * can: fix corrupted payload in send(), hex data was sent as a bytes repr
+  * can: fix receive() always failing with TypeError on Python 3
+  * gsm: return IMEI as str, so split_imei() no longer rejects it
+  * gpio: fix wait_for_edge() raising OverflowError when called without timeout
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 20 Aug 2026 16:20:00 +0400
+
 wb-common (2.3.0) stable; urgency=medium
 
   * Port for Debian 13

--- a/wb_common/can.py
+++ b/wb_common/can.py
@@ -37,7 +37,7 @@ class CanPort:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
-            )
+            )  # pylint: disable=duplicate-code
         except subprocess.CalledProcessError:
             raise RuntimeError("candump failed")  # pylint:disable=raise-missing-from
 

--- a/wb_common/can.py
+++ b/wb_common/can.py
@@ -19,7 +19,7 @@ class CanPort:
     def setup(self):
         # re-initialize iface
         subprocess.call(f"ifconfig {self.iface} down", shell=True)
-        subprocess.call(f"ip link set {self.iface} type can bitrate {self.bitrate}", shell=True)
+        subprocess.call(f"ip link set {self.iface} type can bitrate {int(self.bitrate)}", shell=True)
         subprocess.call(f"ifconfig {self.iface} up", shell=True)
 
     def send(self, addr, data):

--- a/wb_common/can.py
+++ b/wb_common/can.py
@@ -19,12 +19,12 @@ class CanPort:
     def setup(self):
         # re-initialize iface
         subprocess.call(f"ifconfig {self.iface} down", shell=True)
-        subprocess.call(f"ip link set {self.iface} type can bitrate 125000", shell=True)
+        subprocess.call(f"ip link set {self.iface} type can bitrate {self.bitrate}", shell=True)
         subprocess.call(f"ifconfig {self.iface} up", shell=True)
 
     def send(self, addr, data):
         addr_str = hex(addr)[2:][:3].zfill(3)
-        data_str = binascii.hexlify(data)
+        data_str = binascii.hexlify(data).decode("ascii")
         subprocess.call(f"cansend {self.iface} {addr_str}#{data_str}", shell=True)
 
     def receive(self, timeout_ms=1000):
@@ -36,6 +36,7 @@ class CanPort:
                 check=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                text=True,
             )
         except subprocess.CalledProcessError:
             raise RuntimeError("candump failed")  # pylint:disable=raise-missing-from

--- a/wb_common/can.py
+++ b/wb_common/can.py
@@ -30,14 +30,15 @@ class CanPort:
     def receive(self, timeout_ms=1000):
 
         try:
+            # pylint: disable=duplicate-code
             result = subprocess.run(
                 f"candump {self.iface} -s0 -L -T {timeout_ms}",
                 shell=True,
                 check=True,
+                text=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True,
-            )  # pylint: disable=duplicate-code
+            )
         except subprocess.CalledProcessError:
             raise RuntimeError("candump failed")  # pylint:disable=raise-missing-from
 

--- a/wb_common/gpio.py
+++ b/wb_common/gpio.py
@@ -101,9 +101,6 @@ class GPIOHandler:
             self.epoll.unregister(self.gpio_fds[gpio])
 
     def wait_for_edge(self, gpio, edge, timeout=None):
-        if timeout is None:
-            timeout = 1e100
-
         event = threading.Event()
         event.clear()
 

--- a/wb_common/gsm.py
+++ b/wb_common/gsm.py
@@ -30,7 +30,7 @@ def gsm_get_imei():
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
-        )
+        )  # pylint: disable=duplicate-code
         return result.stdout.strip()
     except subprocess.CalledProcessError:
         raise RuntimeError("get imei failed")  # pylint:disable=raise-missing-from

--- a/wb_common/gsm.py
+++ b/wb_common/gsm.py
@@ -23,14 +23,15 @@ def init_baudrate():
 
 def gsm_get_imei():
     try:
+        # pylint: disable=duplicate-code
         result = subprocess.run(
             "wb-gsm imei",
             shell=True,
             check=True,
+            text=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            text=True,
-        )  # pylint: disable=duplicate-code
+        )
         return result.stdout.strip()
     except subprocess.CalledProcessError:
         raise RuntimeError("get imei failed")  # pylint:disable=raise-missing-from

--- a/wb_common/gsm.py
+++ b/wb_common/gsm.py
@@ -24,7 +24,12 @@ def init_baudrate():
 def gsm_get_imei():
     try:
         result = subprocess.run(
-            "wb-gsm imei", shell=True, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            "wb-gsm imei",
+            shell=True,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
         )
         return result.stdout.strip()
     except subprocess.CalledProcessError:


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
  * can: fix corrupted payload in send(), hex data was sent as a bytes repr
  * can: fix receive() always failing with TypeError on Python 3
  * gsm: return IMEI as str, so split_imei() no longer rejects it
  * gpio: fix wait_for_edge() raising OverflowError when called without timeout

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


